### PR TITLE
Adding event extraction & formatter customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,44 @@ In order to enable SQL logging in your application, you'll simply need to add th
 require 'lograge/sql/extension'
 ```
 
+## Customization
+
+By default, the format is a string concatenation of the query name, the query duration and the query itself joined by `\n` newline:
+
+```
+method=GET path=/mypath format=html ...
+Object Load (0.42) SELECT "objects.*" FROM "objects"
+Associations Load (0.42) SELECT "associations.*" FROM "associations" WHERE "associations"."object_id" = "$1"
+```
+
+However, having `Lograge::Formatters::Json.new`, the relevant output is 
+
+```json
+{
+    "sql_queries": "name1 ({duration1}) {query1}\nname2 ({duration2}) query2 ...",
+    "sql_queries_count": 3
+}
+```
+
+To customize the output:
+
+```ruby
+# config/initializers/lograge.rb
+Rails.application.configure do
+
+  # Instead of extracting event as Strings, extract as Hash. You can also extract
+  # additional fields to add to the formatter
+  config.lograge_sql.extract_event = Proc.new do |event|
+    { name: event.payload[:name], duration: event.duration.to_f.round(2), sql: event.payload[:sql] }
+  end
+  # Format the array of extracted events
+  config.lograge_sql.formatter = Proc.new do |sql_queries|
+    sql_queries
+  end
+end
+```
+
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/iMacTia/lograge-sql.

--- a/lib/lograge/sql.rb
+++ b/lib/lograge/sql.rb
@@ -2,6 +2,36 @@ require 'lograge/sql/version'
 
 module Lograge
   module Sql
+    module_function
+
+    # Format SQL log
+    mattr_accessor :formatter
+    # Extract information from SQL event
+    mattr_accessor :extract_event
+
+    # Initialise configuration with fallback to default values
+    def setup(config)
+      Lograge::Sql.formatter     = config.formatter     || default_formatter
+      Lograge::Sql.extract_event = config.extract_event || default_extract_event
+    end
+
+    # By default, the output is a concatenated string of all extracted events
+    def default_formatter
+      Proc.new do |sql_queries|
+        %('#{sql_queries.join("\n")}')
+      end
+    end
+
+    # By default, only extract values required for the default_formatter and 
+    # already convert to a string
+    def default_extract_event
+      Proc.new do |event|
+        "#{event.payload[:name]} (#{event.duration.to_f.round(2)}) #{event.payload[:sql]}"
+      end
+    end
 
   end
 end
+
+# Rails specific configuration
+require 'lograge/sql/railtie' if defined?(Rails)

--- a/lib/lograge/sql.rb
+++ b/lib/lograge/sql.rb
@@ -2,32 +2,37 @@ require 'lograge/sql/version'
 
 module Lograge
   module Sql
-    module_function
+    
+    class << self
 
-    # Format SQL log
-    mattr_accessor :formatter
-    # Extract information from SQL event
-    mattr_accessor :extract_event
+      # Format SQL log
+      attr_accessor :formatter
+      # Extract information from SQL event
+      attr_accessor :extract_event
 
-    # Initialise configuration with fallback to default values
-    def setup(config)
-      Lograge::Sql.formatter     = config.formatter     || default_formatter
-      Lograge::Sql.extract_event = config.extract_event || default_extract_event
-    end
-
-    # By default, the output is a concatenated string of all extracted events
-    def default_formatter
-      Proc.new do |sql_queries|
-        %('#{sql_queries.join("\n")}')
+      # Initialise configuration with fallback to default values
+      def setup(config)
+        Lograge::Sql.formatter     = config.formatter     || default_formatter
+        Lograge::Sql.extract_event = config.extract_event || default_extract_event
       end
-    end
 
-    # By default, only extract values required for the default_formatter and 
-    # already convert to a string
-    def default_extract_event
-      Proc.new do |event|
-        "#{event.payload[:name]} (#{event.duration.to_f.round(2)}) #{event.payload[:sql]}"
+      private
+
+      # By default, the output is a concatenated string of all extracted events
+      def default_formatter
+        Proc.new do |sql_queries|
+          %('#{sql_queries.join("\n")}')
+        end
       end
+
+      # By default, only extract values required for the default_formatter and 
+      # already convert to a string
+      def default_extract_event
+        Proc.new do |event|
+          "#{event.payload[:name]} (#{event.duration.to_f.round(2)}) #{event.payload[:sql]}"
+        end
+      end
+
     end
 
   end

--- a/lib/lograge/sql/extension.rb
+++ b/lib/lograge/sql/extension.rb
@@ -11,7 +11,7 @@ module Lograge
 
         Thread.current[:lograge_sql_queries] = nil
         {
-          sql_queries: %('#{sql_queries.join("\n")}'),
+          sql_queries: Lograge::Sql.formatter.call(sql_queries),
           sql_queries_count: sql_queries.length
         }
       end
@@ -25,7 +25,7 @@ module Lograge
       ActiveRecord::LogSubscriber.runtime += event.duration
       return if event.payload[:name] == 'SCHEMA'
       Thread.current[:lograge_sql_queries] ||= []
-      Thread.current[:lograge_sql_queries] << ("#{event.payload[:name]} (#{event.duration.to_f.round(2)}) #{event.payload[:sql]}")
+      Thread.current[:lograge_sql_queries] << Lograge::Sql.extract_event.call(event)
     end
   end
 end

--- a/lib/lograge/sql/railtie.rb
+++ b/lib/lograge/sql/railtie.rb
@@ -1,0 +1,15 @@
+require 'rails/railtie'
+require 'active_support/ordered_options'
+
+module Lograge
+  module Sql
+    class Railtie < Rails::Railtie
+      # To ensure that configuration is not nil when initialise Lograge::Sql.setup
+      config.lograge_sql = ActiveSupport::OrderedOptions.new
+
+      config.after_initialize do |app|
+        Lograge::Sql.setup(app.config.lograge_sql)
+      end
+    end
+  end
+end

--- a/lib/lograge/sql/version.rb
+++ b/lib/lograge/sql/version.rb
@@ -1,5 +1,5 @@
 module Lograge
   module Sql
-    VERSION = '0.2.0'
+    VERSION = '0.2.1'
   end
 end


### PR DESCRIPTION
When `lograge-sql` works well when Lograge raw format is used, it might not be convenient to have a concatenated string when using Lograge JSON format. More globally, this suggestion allows a bit of flexibility:

- Log output can be customized via a formatter
- The formatter is fed by a event extractor. This allows user to extract additional fields (e.g. `payload[:cached]`
- Such customization are accessible via a Railtie. If no configuration is done, it works as currently defined and this change is completely invisible

<sub>Being a Ruby beginner, feel free to correct the code</sub>

---
For reference, ActiveRecord default event extractor and formatter:
https://www.rubydoc.info/gems/activerecord/ActiveRecord/LogSubscriber#sql-instance_method