### PR TITLE
Add rubocop to standard set of tests run before deployment.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,12 @@
 
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
+require 'rubocop/rake_task'
 
 RSpec::Core::RakeTask.new(:spec)
+RuboCop::RakeTask.new(:rubocop) do |t|
+  t.options = ['--display-cop-names']
+end
 
-task default: :spec
+desc 'Run all rubocop and rspec tests'
+task default: %i[spec rubocop]


### PR DESCRIPTION
The repository passes all the rubocop tests anyway, so it doesn't hurt
to double check the syntax before deploying to rubygems.