### PR TITLE
Upgrade bundler to 2.0 and remove support for ruby 2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,15 @@
 language: ruby
 cache: bundler
 rvm:
-  - 2.3
   - 2.4
   - 2.5
   - 2.6
-before_install:
-  - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
-  - gem install bundler -v '~> 1.17'
 gemfile:
   - gemfiles/lograge10.gemfile
   - gemfiles/lograge11.gemfile
+before_install:
+  - gem update --system
+  - gem install bundler
 deploy:
   provider: rubygems
   api_key:

--- a/lograge-sql.gemspec
+++ b/lograge-sql.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'activerecord', '>= 4', '< 6.0'
   spec.add_runtime_dependency 'lograge', '~> 0.4'
 
-  spec.add_development_dependency 'bundler', '~> 1.0'
+  spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rubocop'


### PR DESCRIPTION
Bundler 2.0 has been released for 6 months, and is stable enough. This is just a development dependancy, so it won't affect any app requiring this gem.

Ruby 2.3 has been end-of-lifed, and it's not really worth spending time supporting anymore.