### PR TITLE
Allow use with rails 6

### DIFF
--- a/lograge-sql.gemspec
+++ b/lograge-sql.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'activerecord', '>= 4', '< 6.0'
+  spec.add_runtime_dependency 'activerecord', '>= 4', '< 7.0'
   spec.add_runtime_dependency 'lograge', '~> 0.4'
 
   spec.add_development_dependency 'bundler', '~> 1.0'


### PR DESCRIPTION
The gem has worked with the rc1 and rc2 rails 6 releases, logging the SQL and logging the count of SQL queries fine.