### PR TITLE
Improved thread safety with request_store

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Object Load (0.42) SELECT "objects.*" FROM "objects"
 Associations Load (0.42) SELECT "associations.*" FROM "associations" WHERE "associations"."object_id" = "$1"
 ```
 
-However, having `Lograge::Formatters::Json.new`, the relevant output is 
+However, having `Lograge::Formatters::Json.new`, the relevant output is
 
 ```json
 {
@@ -60,6 +60,9 @@ Rails.application.configure do
 end
 ```
 
+#### Thread-safety
+
+[Depending on the web server in your project](https://github.com/steveklabnik/request_store#the-problem) you might benefit from improved thread-safety by adding [`request_store`](https://github.com/steveklabnik/request_store) to your Gemfile. It will be automatically picked up by `lograge-sql`.
 
 ## Contributing
 

--- a/lib/lograge/sql.rb
+++ b/lib/lograge/sql.rb
@@ -10,14 +10,15 @@ module Lograge
       attr_accessor :formatter
       # Extract information from SQL event
       attr_accessor :extract_event
-      # Thread storage
-      attr_accessor :store
 
       # Initialise configuration with fallback to default values
       def setup(config)
         Lograge::Sql.formatter     = config.formatter     || default_formatter
         Lograge::Sql.extract_event = config.extract_event || default_extract_event
-        Lograge::Sql.store = defined?(RequestStore.store) ? RequestStore.store : Thread.current
+      end
+
+      def store
+        defined?(RequestStore.store) ? RequestStore.store : Thread.current
       end
 
       private

--- a/lib/lograge/sql.rb
+++ b/lib/lograge/sql.rb
@@ -18,7 +18,7 @@ module Lograge
       end
 
       def store
-        defined?(RequestStore.store) ? RequestStore.store : Thread.current
+        defined?(RequestStore) ? RequestStore.store : Thread.current
       end
 
       private

--- a/lib/lograge/sql.rb
+++ b/lib/lograge/sql.rb
@@ -15,6 +15,7 @@ module Lograge
       def setup(config)
         Lograge::Sql.formatter     = config.formatter     || default_formatter
         Lograge::Sql.extract_event = config.extract_event || default_extract_event
+        Lograge::Sql.store = defined?(RequestStore.store) ? RequestStore.store : Thread.current
       end
 
       private

--- a/lib/lograge/sql.rb
+++ b/lib/lograge/sql.rb
@@ -10,6 +10,8 @@ module Lograge
       attr_accessor :formatter
       # Extract information from SQL event
       attr_accessor :extract_event
+      # Thread storage
+      attr_accessor :store
 
       # Initialise configuration with fallback to default values
       def setup(config)

--- a/lib/lograge/sql/extension.rb
+++ b/lib/lograge/sql/extension.rb
@@ -11,10 +11,10 @@ module Lograge
 
       # Collects all SQL queries stored in the Thread during request processing
       def extract_sql_queries
-        sql_queries = Thread.current[:lograge_sql_queries]
+        sql_queries = RequestStore.store[:lograge_sql_queries]
         return {} unless sql_queries
 
-        Thread.current[:lograge_sql_queries] = nil
+        RequestStore.store[:lograge_sql_queries] = nil
         {
           sql_queries: Lograge::Sql.formatter.call(sql_queries),
           sql_queries_count: sql_queries.length
@@ -33,8 +33,8 @@ module Lograge
       ActiveRecord::LogSubscriber.runtime += event.duration
       return if event.payload[:name] == 'SCHEMA'
 
-      Thread.current[:lograge_sql_queries] ||= []
-      Thread.current[:lograge_sql_queries] << Lograge::Sql.extract_event.call(event)
+      RequestStore.store[:lograge_sql_queries] ||= []
+      RequestStore.store[:lograge_sql_queries] << Lograge::Sql.extract_event.call(event)
     end
   end
 end

--- a/lib/lograge/sql/extension.rb
+++ b/lib/lograge/sql/extension.rb
@@ -11,10 +11,10 @@ module Lograge
 
       # Collects all SQL queries stored in the Thread during request processing
       def extract_sql_queries
-        sql_queries = RequestStore.store[:lograge_sql_queries]
+        sql_queries = Lograge::Sql.store[:lograge_sql_queries]
         return {} unless sql_queries
 
-        RequestStore.store[:lograge_sql_queries] = nil
+        Lograge::Sql.store[:lograge_sql_queries] = nil
         {
           sql_queries: Lograge::Sql.formatter.call(sql_queries),
           sql_queries_count: sql_queries.length
@@ -33,8 +33,8 @@ module Lograge
       ActiveRecord::LogSubscriber.runtime += event.duration
       return if event.payload[:name] == 'SCHEMA'
 
-      RequestStore.store[:lograge_sql_queries] ||= []
-      RequestStore.store[:lograge_sql_queries] << Lograge::Sql.extract_event.call(event)
+      Lograge::Sql.store[:lograge_sql_queries] ||= []
+      Lograge::Sql.store[:lograge_sql_queries] << Lograge::Sql.extract_event.call(event)
     end
   end
 end

--- a/lograge-sql.gemspec
+++ b/lograge-sql.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'activerecord', '>= 4', '< 7.0'
   spec.add_runtime_dependency 'lograge', '~> 0.4'
+  spec.add_runtime_dependency 'request_store', '>= 1', '< 2'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/lograge-sql.gemspec
+++ b/lograge-sql.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'activerecord', '>= 4', '< 7.0'
   spec.add_runtime_dependency 'lograge', '~> 0.4'
-  spec.add_runtime_dependency 'request_store', '>= 1', '< 2'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
I have been having some thread safety errors in production and thought it would be good to replace `Thread.current` by [`request_store`](https://github.com/steveklabnik/request_store). There is an explanation in the README for why it is safer.

What do you think?