### PR TITLE
Add config option `keep_default_active_record_log`

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ In order to enable SQL logging in your application, you'll simply need to add th
 require 'lograge/sql/extension'
 ```
 
+By default, Lograge::Sql disables default logging on ActiveRecord. To preserve default logging, add this to your lograge initializer:
+
+```ruby
+config.lograge_sql.keep_default_active_record_log = true
+```
+
 ## Customization
 
 By default, the format is a string concatenation of the query name, the query duration and the query itself joined by `\n` newline:

--- a/lib/lograge/sql.rb
+++ b/lib/lograge/sql.rb
@@ -15,6 +15,12 @@ module Lograge
       def setup(config)
         Lograge::Sql.formatter     = config.formatter     || default_formatter
         Lograge::Sql.extract_event = config.extract_event || default_extract_event
+        # Disable existing ActiveRecord logging
+        unless config.keep_default_active_record_log
+          ActiveSupport::LogSubscriber.log_subscribers.each do |subscriber|
+            Lograge.unsubscribe(:active_record, subscriber) if subscriber.is_a?(ActiveRecord::LogSubscriber)
+          end
+        end
       end
 
       def store

--- a/lib/lograge/sql/extension.rb
+++ b/lib/lograge/sql/extension.rb
@@ -45,8 +45,4 @@ else
   Lograge::LogSubscribers::ActionController.prepend Lograge::Sql::Extension
 end
 
-ActiveSupport::LogSubscriber.log_subscribers.each do |subscriber|
-  Lograge.unsubscribe(:active_record, subscriber) if subscriber.is_a?(ActiveRecord::LogSubscriber)
-end
-
 Lograge::ActiveRecordLogSubscriber.attach_to :active_record


### PR DESCRIPTION
Closes iMacTia/lograge-sql#11 ("Prevent Default ActiveRecord Logging From Being Disabled")