### PR TITLE
Use ActiveSupport.on_load

### DIFF
--- a/lib/lograge/sql/railtie.rb
+++ b/lib/lograge/sql/railtie.rb
@@ -10,10 +10,8 @@ module Lograge
       # To ensure that configuration is not nil when initialise Lograge::Sql.setup
       config.lograge_sql = ActiveSupport::OrderedOptions.new
 
-      initializer 'lograge-sql' do |app|
-        ActiveSupport.on_load(:active_record) do
-          Lograge::Sql.setup(app.config.lograge_sql)
-        end
+      config.to_prepare do |app|
+        Lograge::Sql.setup(Rails.application.config.lograge_sql)
       end
     end
   end

--- a/lib/lograge/sql/railtie.rb
+++ b/lib/lograge/sql/railtie.rb
@@ -10,8 +10,10 @@ module Lograge
       # To ensure that configuration is not nil when initialise Lograge::Sql.setup
       config.lograge_sql = ActiveSupport::OrderedOptions.new
 
-      config.after_initialize do |app|
-        Lograge::Sql.setup(app.config.lograge_sql)
+      initializer 'lograge-sql' do |app|
+        ActiveSupport.on_load(:active_record) do
+          Lograge::Sql.setup(app.config.lograge_sql)
+        end
       end
     end
   end


### PR DESCRIPTION
Hi @iMacTia .
Currently, `Lograge::Sql.setup` is called in `config.after_initialize` .
In my case, it's late. So I use `ActiveSupport.on_load :active_record`, it is called when `ActiveRecord::Base` is evaluated.
https://api.rubyonrails.org/classes/ActiveSupport/LazyLoadHooks.html

My Rails application's model executes query to database when it is loaded.
Because my code defines alias_attribute automatically. `attributes_names` needs database access.

```
class SomeModel < ApplicationRecord
  ...
  define_alias_attributes_name
  ...
end

class ApplicationRecord < ActiveRecord::Base
  ...
  def self.define_alias_attributes_name
    attribute_names.each do |attribute_name|
      alias_name = ...
      alias_attribute(alias_name, attribute_name)
    end
  end
  ...
end
```

`config.after_initialize` is called after `eager_load`.
https://github.com/rails/rails/blob/master/railties/lib/rails/application.rb#L59-L60

And then error occurs when Rails initialize.

```
"Could not log \"sql.active_record\" event. NoMethodError: undefined method `call' for nil:NilClass 
[\"/usr/local/bundle/gems/lograge-sql-1.2.0/lib/lograge/sql/extension.rb:37:in `sql'\"
```