### PR TITLE
Add option to keep just a query counter

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,16 @@ Rails.application.configure do
 end
 ```
 
+Lograge-sql keeps an array with all sql queries in memory for the duration of request.
+You can make it more memory efficient by keeping just a query counter:
+
+```ruby
+# config/initializers/lograge.rb
+Rails.application.configure do
+  config.lograge_sql.counter_only = true
+end
+```
+
 #### Thread-safety
 
 [Depending on the web server in your project](https://github.com/steveklabnik/request_store#the-problem) you might benefit from improved thread-safety by adding [`request_store`](https://github.com/steveklabnik/request_store) to your Gemfile. It will be automatically picked up by `lograge-sql`.

--- a/lib/lograge/active_record_log_subscriber.rb
+++ b/lib/lograge/active_record_log_subscriber.rb
@@ -9,8 +9,13 @@ module Lograge
       ActiveRecord::LogSubscriber.runtime += event.duration
       return if event.payload[:name] == 'SCHEMA'
 
-      Lograge::Sql.store[:lograge_sql_queries] ||= []
-      Lograge::Sql.store[:lograge_sql_queries] << Lograge::Sql.extract_event.call(event)
+      if Lograge::Sql.counter_only
+        Lograge::Sql.store[:lograge_sql_queries_count] ||= 0
+        Lograge::Sql.store[:lograge_sql_queries_count] += 1
+      else
+        Lograge::Sql.store[:lograge_sql_queries] ||= []
+        Lograge::Sql.store[:lograge_sql_queries] << Lograge::Sql.extract_event.call(event)
+      end
     end
   end
 end

--- a/lib/lograge/sql.rb
+++ b/lib/lograge/sql.rb
@@ -11,11 +11,14 @@ module Lograge
       attr_accessor :formatter
       # Extract information from SQL event
       attr_accessor :extract_event
+      # Keep just a counter of SQL queries
+      attr_accessor :counter_only
 
       # Initialise configuration with fallback to default values
       def setup(config)
         Lograge::Sql.formatter     = config.formatter     || default_formatter
         Lograge::Sql.extract_event = config.extract_event || default_extract_event
+        Lograge::Sql.counter_only  = config.counter_only  || false
 
         # Disable existing ActiveRecord logging
         unless config.keep_default_active_record_log

--- a/lib/lograge/sql/extension.rb
+++ b/lib/lograge/sql/extension.rb
@@ -13,14 +13,24 @@ module Lograge
 
       # Collects all SQL queries stored in the Thread during request processing
       def extract_sql_queries
-        sql_queries = Lograge::Sql.store[:lograge_sql_queries]
-        return {} unless sql_queries
+        if Lograge::Sql.counter_only
+          lograge_sql_queries_count = Lograge::Sql.store[:lograge_sql_queries_count]
+          return {} unless lograge_sql_queries_count
 
-        Lograge::Sql.store[:lograge_sql_queries] = nil
-        {
-          sql_queries: Lograge::Sql.formatter.call(sql_queries),
-          sql_queries_count: sql_queries.length
-        }
+          Lograge::Sql.store[:lograge_sql_queries_count] = nil
+          {
+            sql_queries_count: lograge_sql_queries_count
+          }
+        else
+          sql_queries = Lograge::Sql.store[:lograge_sql_queries]
+          return {} unless sql_queries
+
+          Lograge::Sql.store[:lograge_sql_queries] = nil
+          {
+            sql_queries: Lograge::Sql.formatter.call(sql_queries),
+            sql_queries_count: sql_queries.length
+          }
+        end
       end
     end
   end


### PR DESCRIPTION
Unfortunatelly keeping all SQL queries in memory was too much for us.

This MR adds a simple option (counter_only) that when enabled, makes lograge_sql keep just a simple counter of sql queries.

Btw, this lograge_sql is incredibly useful. Thanks for that :heart: 