### PR TITLE
test: Configure RSpec to run sans monkeypatches

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
 --format documentation
 --color
+--require spec_helper

--- a/spec/lograge/sql_spec.rb
+++ b/spec/lograge/sql_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-
-describe Lograge::Sql do
+RSpec.describe Lograge::Sql do
   let(:subscriber) do
     if defined?(Lograge::RequestLogSubscriber)
       Lograge::RequestLogSubscriber

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,5 +9,5 @@ require 'lograge'
 require 'lograge/sql'
 
 RSpec.configure do |config|
-  config.disable_monkey_patching!
+  config.disable_monkey_patching! # rubocop:disable Style/SymbolProc
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,3 +7,7 @@ $LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 require 'delegate'
 require 'lograge'
 require 'lograge/sql'
+
+RSpec.configure do |config|
+  config.disable_monkey_patching!
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,6 @@ require 'delegate'
 require 'lograge'
 require 'lograge/sql'
 
-RSpec.configure do |config|
-  config.disable_monkey_patching! # rubocop:disable Style/SymbolProc
+RSpec.configure do |config| # rubocop:disable Style/SymbolProc
+  config.disable_monkey_patching!
 end


### PR DESCRIPTION
This PR removes RSpec top-level includes into Object etc.