### PR TITLE
Fix query runtime being incremented twice

### DIFF
--- a/lib/lograge/active_record_log_subscriber.rb
+++ b/lib/lograge/active_record_log_subscriber.rb
@@ -12,15 +12,15 @@ module Lograge
       Lograge::Sql.store[:lograge_sql_queries] ||= []
       Lograge::Sql.store[:lograge_sql_queries] << Lograge::Sql.extract_event.call(event)
     end
-    
+
     private
-    
+
     # Add the event duration to the overall ActiveRecord::LogSubscriber.runtime;
     # note we don't do this when `keep_default_active_record_log` is enabled,
     # as ActiveRecord is already adding the duration.
     def increase_runtime_duration(event)
       return if Rails.application.config.lograge_sql.keep_default_active_record_log
-      
+
       ActiveRecord::LogSubscriber.runtime += event.duration
     end
   end

--- a/spec/lograge/active_record_log_subscriber_spec.rb
+++ b/spec/lograge/active_record_log_subscriber_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+RSpec.describe Lograge::ActiveRecordLogSubscriber do
+  describe '#sql' do
+    subject(:log_subscriber) { described_class.new }
+    let(:event) { instance_double('ActiveSupport::Notification::Event.new', duration: 20, payload: {}) }
+    let(:rails) { double('rails') }
+    let(:ar_log_subscriber) { double('ActiveRecord::LogSubscriber', runtime: 100) }
+
+    before do
+      stub_const('Rails', rails)
+      stub_const('ActiveRecord::LogSubscriber', ar_log_subscriber)
+      Lograge::Sql.extract_event = proc {}
+    end
+
+    context 'with keep_default_active_record_log not set' do
+      before do
+        allow(Rails).to receive_message_chain('application.config.lograge_sql.keep_default_active_record_log') { nil }
+      end
+      it 'adds duration to ActiveRecord::LogSubscriber runtime' do
+        expect(ar_log_subscriber).to receive(:runtime=).with(120)
+
+        log_subscriber.sql(event)
+      end
+    end
+    context 'with keep_default_active_record_log set to true' do
+      before do
+        allow(Rails).to receive_message_chain('application.config.lograge_sql.keep_default_active_record_log') { true }
+      end
+      it 'does not add duration to ActiveRecord::LogSubscriber runtime' do
+        expect(ar_log_subscriber).to_not receive(:runtime=)
+
+        log_subscriber.sql(event)
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,7 @@ $LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 require 'delegate'
 require 'lograge'
 require 'lograge/sql'
+require 'lograge/active_record_log_subscriber'
 
 RSpec.configure do |config| # rubocop:disable Style/SymbolProc
   config.disable_monkey_patching!


### PR DESCRIPTION
Fix an issue causing the query runtime being incremented twice when `lograge_sql.keep_default_active_record_log` is enabled.
This is because both `Lograge::Sql` and `ActiveRecord` increment it for every query logged.

Fixes #37