### PR TITLE
Spec for double query runtime increment

### DIFF
--- a/spec/lograge/active_record_log_subscriber_spec.rb
+++ b/spec/lograge/active_record_log_subscriber_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+RSpec.describe Lograge::ActiveRecordLogSubscriber do
+  describe '#sql' do
+    subject(:log_subscriber) { described_class.new }
+    let(:event) { instance_double('ActiveSupport::Notification::Event.new', duration: 20, payload: {}) }
+    let(:rails) { double('rails') }
+    let(:ar_log_subscriber) { double('ActiveRecord::LogSubscriber', runtime: 100) }
+
+    before do
+      stub_const('Rails', rails)
+      stub_const('ActiveRecord::LogSubscriber', ar_log_subscriber)
+      Lograge::Sql.extract_event = proc {}
+    end
+
+    context 'with keep_default_active_record_log not set' do
+      before do
+        allow(Rails).to receive_message_chain('application.config.lograge_sql.keep_default_active_record_log') { nil }
+      end
+      it 'adds duration to ActiveRecord::LogSubscriber runtime' do
+        expect(ar_log_subscriber).to receive(:runtime=).with(120)
+
+        log_subscriber.sql(event)
+      end
+    end
+    context 'with keep_default_active_record_log set to true' do
+      before do
+        allow(Rails).to receive_message_chain('application.config.lograge_sql.keep_default_active_record_log') { true }
+      end
+      it 'does not add duration to ActiveRecord::LogSubscriber runtime' do
+        expect(ar_log_subscriber).to_not receive(:runtime=)
+
+        log_subscriber.sql(event)
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,7 @@ $LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 require 'delegate'
 require 'lograge'
 require 'lograge/sql'
+require 'lograge/active_record_log_subscriber'
 
 RSpec.configure do |config| # rubocop:disable Style/SymbolProc
   config.disable_monkey_patching!


### PR DESCRIPTION
Adds a spec around `Lograge::ActiveRecordLogSubscriber#sql` to ensure that when the config option `keep_default_active_record_log` is set, the `ActiveRecord::LogSubscriber.runtime` isn't incremented. 

I tried to keep in style with what was already there, however it may be able to be accomplished in a better way and I'm happy to change if I need to. 

Since the `#sql` method is calling both `Rails` and `ActiveRecord`, i just stubbed the constants in a `before` block with doubles. I didn't want to have to load in the entire framework just for the tests, and all I'm really concerned with is that the `#runtime=` method isn't called when the `keep_default_active_record_log` is truthy. 

I added a require to the spec helper for `active_record_log_subscriber`, too. I don't think it's going to add much time at all to the spec startup, but I can move it somewhere else if that's desired.

I also targeted the merge to the `issue-37/fix-double-query-runtime` branch directly, since these tests will fail without the fix there.