### PR TITLE
Add option min_duration_ms to filter SQL Events

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,18 @@ Rails.application.configure do
 end
 ```
 
+`Lograge-sql` only stores any events by `limit_duration` condition.
+It very helpful if you want to detect `Slow SQL queries`
+
+```ruby
+# config/initializers/lograge.rb
+Rails.application.configure do
+  # Set limitted of SQL duration if you want to filter (unit: milliseconds)
+  # Defaults is zero
+  config.lograge_sql.limit_duration = 5000
+end
+```
+
 #### Thread-safety
 
 [Depending on the web server in your project](https://github.com/steveklabnik/request_store#the-problem) you might benefit from improved thread-safety by adding [`request_store`](https://github.com/steveklabnik/request_store) to your Gemfile. It will be automatically picked up by `lograge-sql`.
@@ -73,4 +85,3 @@ end
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/iMacTia/lograge-sql.
-

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Rails.application.configure do
 end
 ```
 
-`Lograge-sql` only stores any events by `limit_duration` condition.
+`Lograge-sql` only stores any events by `min_duration_ms` condition.
 It very helpful if you want to detect `Slow SQL queries`
 
 ```ruby
@@ -74,7 +74,7 @@ It very helpful if you want to detect `Slow SQL queries`
 Rails.application.configure do
   # Set limitted of SQL duration if you want to filter (unit: milliseconds)
   # Defaults is zero
-  config.lograge_sql.limit_duration = 5000
+  config.lograge_sql.min_duration_ms = 5000
 end
 ```
 

--- a/lib/lograge/active_record_log_subscriber.rb
+++ b/lib/lograge/active_record_log_subscriber.rb
@@ -9,9 +9,9 @@ module Lograge
       ActiveRecord::LogSubscriber.runtime += event.duration
       return if event.payload[:name] == 'SCHEMA'
 
-      # Only store SQL events if `event.duration` greater than +limit_duration+ configured
-      # Do not need to check +limit_duration+ present before
-      return if event.duration.to_f.round(2) < Lograge::Sql.limit_duration.to_f
+      # Only store SQL events if `event.duration` is greater than the configured +min_duration+
+      # No need to check if +min_duration+ is present before as it defaults to 0
+      return if event.duration.to_f.round(2) < Lograge::Sql.min_duration_ms.to_f
 
       Lograge::Sql.store[:lograge_sql_queries] ||= []
       Lograge::Sql.store[:lograge_sql_queries] << Lograge::Sql.extract_event.call(event)

--- a/lib/lograge/active_record_log_subscriber.rb
+++ b/lib/lograge/active_record_log_subscriber.rb
@@ -9,6 +9,10 @@ module Lograge
       ActiveRecord::LogSubscriber.runtime += event.duration
       return if event.payload[:name] == 'SCHEMA'
 
+      # Only store SQL events if `event.duration` greater than +limit_duration+ configured
+      # Do not need to check +limit_duration+ present before
+      return if event.duration.to_f.round(2) < Lograge::Sql.limit_duration.to_f
+
       Lograge::Sql.store[:lograge_sql_queries] ||= []
       Lograge::Sql.store[:lograge_sql_queries] << Lograge::Sql.extract_event.call(event)
     end

--- a/lib/lograge/sql.rb
+++ b/lib/lograge/sql.rb
@@ -12,13 +12,13 @@ module Lograge
       # Extract information from SQL event
       attr_accessor :extract_event
       # Filter SQL events by duration
-      attr_accessor :limit_duration
+      attr_accessor :min_duration_ms
 
       # Initialise configuration with fallback to default values
       def setup(config)
-        Lograge::Sql.formatter      = config.formatter      || default_formatter
-        Lograge::Sql.extract_event  = config.extract_event  || default_extract_event
-        Lograge::Sql.limit_duration = config.limit_duration || 0
+        Lograge::Sql.formatter       = config.formatter       || default_formatter
+        Lograge::Sql.extract_event   = config.extract_event   || default_extract_event
+        Lograge::Sql.min_duration_ms = config.min_duration_ms || 0
 
         # Disable existing ActiveRecord logging
         unless config.keep_default_active_record_log

--- a/lib/lograge/sql.rb
+++ b/lib/lograge/sql.rb
@@ -11,11 +11,14 @@ module Lograge
       attr_accessor :formatter
       # Extract information from SQL event
       attr_accessor :extract_event
+      # Filter SQL events by duration
+      attr_accessor :limit_duration
 
       # Initialise configuration with fallback to default values
       def setup(config)
-        Lograge::Sql.formatter     = config.formatter     || default_formatter
-        Lograge::Sql.extract_event = config.extract_event || default_extract_event
+        Lograge::Sql.formatter      = config.formatter      || default_formatter
+        Lograge::Sql.extract_event  = config.extract_event  || default_extract_event
+        Lograge::Sql.limit_duration = config.limit_duration || 0
 
         # Disable existing ActiveRecord logging
         unless config.keep_default_active_record_log


### PR DESCRIPTION
Add option `min_duration_ms` to filter SQL Events

This option very helpful to filter `Slow SQL Queries`

`lograge-sql` is also incredible. Thank you 🥰