### PR TITLE
Add option `query_filter` to allow filter out sensitive data

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,16 @@ Rails.application.configure do
 end
 ```
 
+
+### Filtering out sensitive info in SQL logs
+By default, `lograge-sql` will log full query but if you have sensitive data that need to be filtered out, you can set `query_filter` config:
+
+```ruby
+Rails.application.configure do
+  config.lograge_sql.query_filter = ->(query) { query.gsub(/custom_regexp/, "[FILTERED]".freeze) }
+end
+```
+
 ### Thread-safety
 
 [Depending on the web server in your project](https://github.com/steveklabnik/request_store#the-problem) you might benefit from improved thread-safety by adding [`request_store`](https://github.com/steveklabnik/request_store) to your Gemfile. It will be automatically picked up by `lograge-sql`.

--- a/lib/lograge/active_record_log_subscriber.rb
+++ b/lib/lograge/active_record_log_subscriber.rb
@@ -13,6 +13,9 @@ module Lograge
       # No need to check if +min_duration+ is present before as it defaults to 0
       return if event.duration.to_f.round(2) < Lograge::Sql.min_duration_ms.to_f
 
+      # Filtering out sensitive info in SQL query if custom query_filter is provided
+      event.payload[:sql] = Lograge::Sql.query_filter.call(event.payload[:sql]) if Lograge::Sql.query_filter
+
       Lograge::Sql.store[:lograge_sql_queries] ||= []
       Lograge::Sql.store[:lograge_sql_queries] << Lograge::Sql.extract_event.call(event)
     end

--- a/lib/lograge/sql.rb
+++ b/lib/lograge/sql.rb
@@ -13,12 +13,15 @@ module Lograge
       attr_accessor :extract_event
       # Filter SQL events by duration
       attr_accessor :min_duration_ms
+      # Filter SQL query
+      attr_accessor :query_filter
 
       # Initialise configuration with fallback to default values
       def setup(config)
         Lograge::Sql.formatter       = config.formatter       || default_formatter
         Lograge::Sql.extract_event   = config.extract_event   || default_extract_event
         Lograge::Sql.min_duration_ms = config.min_duration_ms || 0
+        Lograge::Sql.query_filter    = config.query_filter
 
         # Disable existing ActiveRecord logging
         unsubscribe_log_subscribers unless config.keep_default_active_record_log

--- a/spec/lograge/active_record_log_subscriber_spec.rb
+++ b/spec/lograge/active_record_log_subscriber_spec.rb
@@ -55,5 +55,25 @@ RSpec.describe Lograge::ActiveRecordLogSubscriber do
         expect(Lograge::Sql.store[:lograge_sql_queries]).to be_nil
       end
     end
+
+    context 'with custom filter' do
+      let(:query_filter) { instance_double(Proc, call: {}) }
+
+      before do
+        allow(Rails).to receive_message_chain('application.config.lograge_sql.keep_default_active_record_log') { true }
+        allow(event).to receive(:payload).and_return({ sql: "foo" })
+        Lograge::Sql.query_filter = query_filter
+      end
+
+      after do
+        # reset filter after test
+        Lograge::Sql.query_filter = nil
+      end
+
+      it 'apply filter to sql payload' do
+        log_subscriber.sql(event)
+        expect(query_filter).to have_received(:call).with("foo")
+      end
+    end
   end
 end


### PR DESCRIPTION
Hi @iMacTia,

I'm implement suggestion from https://github.com/iMacTia/lograge-sql/issues/50: Add a configurable lambda to apply the filtering to `event.payload[:sql]`.

Although currently, this already possible by config `extract_event` or `formatter` but this seem cleaner if we just want to filter sensitive data out.


