### PR TITLE
Fix deprecated `ActiveRecord::LogSubscriber#runtime` method

### DIFF
--- a/lib/lograge/active_record_log_subscriber.rb
+++ b/lib/lograge/active_record_log_subscriber.rb
@@ -15,13 +15,13 @@ module Lograge
 
     private
 
-    # Add the event duration to the overall ActiveRecord::LogSubscriber.runtime;
+    # Add the event duration to the overall ActiveRecord::RuntimeRegistry.sql_runtime;
     # note we don't do this when `keep_default_active_record_log` is enabled,
     # as ActiveRecord is already adding the duration.
     def increase_runtime_duration(event)
       return if Rails.application.config.lograge_sql.keep_default_active_record_log
 
-      ActiveRecord::LogSubscriber.runtime += event.duration
+      ActiveRecord::RuntimeRegistry.sql_runtime += event.duration
     end
 
     def filter_query(event)

--- a/spec/lograge/active_record_log_subscriber_spec.rb
+++ b/spec/lograge/active_record_log_subscriber_spec.rb
@@ -5,11 +5,11 @@ RSpec.describe Lograge::ActiveRecordLogSubscriber do
     subject(:log_subscriber) { described_class.new }
     let(:event) { instance_double('ActiveSupport::Notification::Event.new', duration: 20, payload: {}) }
     let(:rails) { double('rails') }
-    let(:ar_log_subscriber) { double('ActiveRecord::LogSubscriber', runtime: 100) }
+    let(:ar_runtime_registry) { double('ActiveRecord::RuntimeRegistry', sql_runtime: 100.0) }
 
     before do
       stub_const('Rails', rails)
-      stub_const('ActiveRecord::LogSubscriber', ar_log_subscriber)
+      stub_const('ActiveRecord::RuntimeRegistry', ar_runtime_registry)
       Lograge::Sql.extract_event = proc {}
       Lograge::Sql.store.clear
     end
@@ -19,8 +19,8 @@ RSpec.describe Lograge::ActiveRecordLogSubscriber do
         allow(Rails).to receive_message_chain('application.config.lograge_sql.keep_default_active_record_log') { nil }
       end
 
-      it 'adds duration to ActiveRecord::LogSubscriber runtime' do
-        expect(ar_log_subscriber).to receive(:runtime=).with(120)
+      it 'adds duration to ActiveRecord::RuntimeRegistry sql_runtime' do
+        expect(ar_runtime_registry).to receive(:sql_runtime=).with(120.0)
 
         log_subscriber.sql(event)
       end
@@ -31,8 +31,8 @@ RSpec.describe Lograge::ActiveRecordLogSubscriber do
         allow(Rails).to receive_message_chain('application.config.lograge_sql.keep_default_active_record_log') { true }
       end
 
-      it 'does not add duration to ActiveRecord::LogSubscriber runtime' do
-        expect(ar_log_subscriber).to_not receive(:runtime=)
+      it 'does not add duration to ActiveRecord::RuntimeRegistry sql_runtime' do
+        expect(ar_runtime_registry).to_not receive(:sql_runtime=)
 
         log_subscriber.sql(event)
       end


### PR DESCRIPTION
This commit fixes the deprecation warning introduced in rails/rails#46041

Fixes https://github.com/iMacTia/lograge-sql/issues/54