### PR TITLE
Add configuration to filter out sql queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,20 @@ Rails.application.configure do
 end
 ```
 
+### Filtering sql queries by name
+
+You can filter out queries using the `query_name_denylist` configuration. 
+This takes an array of regular expressions to match against the query name. If the query name matches any of the regular expressions, it will be ignored. By default, `lograge-sql` ignores queries named `SCHEMA` and queries from the `SolidCable` namespace.
+If you are using Solid Cable in your project, be careful  when removing this default value as it will cause a [memory leak](https://github.com/iMacTia/lograge-sql/issues/59).
+
+```ruby
+# config/initializers/lograge.rb
+Rails.application.configure do
+  # Defaults is [/\ASCHEMA\z/, /\ASolidCable::/]
+  config.lograge_sql.query_name_denylist << /\AEXACT NAME TO IGNORE\z/
+end
+```
+
 ### Output Customization
 
 By default, the format is a string concatenation of the query name, the query duration and the query itself joined by `\n` newline:

--- a/lib/lograge/active_record_log_subscriber.rb
+++ b/lib/lograge/active_record_log_subscriber.rb
@@ -33,7 +33,7 @@ module Lograge
     end
 
     def valid?(event)
-      return false if event.payload[:name] == 'SCHEMA'
+      return false if event.payload[:name]&.match?(Regexp.union(Lograge::Sql.query_name_denylist))
 
       # Only store SQL events if `event.duration` is greater than the configured +min_duration+
       # No need to check if +min_duration+ is present before as it defaults to 0

--- a/lib/lograge/sql.rb
+++ b/lib/lograge/sql.rb
@@ -15,6 +15,8 @@ module Lograge
       attr_accessor :min_duration_ms
       # Filter SQL query
       attr_accessor :query_filter
+      # Filter wich SQL queries to store
+      attr_accessor :query_name_denylist
 
       # Initialise configuration with fallback to default values
       def setup(config)
@@ -22,6 +24,7 @@ module Lograge
         Lograge::Sql.extract_event   = config.extract_event   || default_extract_event
         Lograge::Sql.min_duration_ms = config.min_duration_ms || 0
         Lograge::Sql.query_filter    = config.query_filter
+        Lograge::Sql.query_name_denylist = config.query_name_denylist || [/\ASCHEMA\z/, /\ASolidCable::/]
 
         # Disable existing ActiveRecord logging
         unsubscribe_log_subscribers unless config.keep_default_active_record_log


### PR DESCRIPTION
This pull request introduces a new feature to filter SQL queries by name using a denylist configuration.

### SQL Query Name Denylist

* Added a `query_name_denylist` configuration option to filter out SQL queries by name using regular expressions.
* Updated the `valid?` method in `lib/lograge/active_record_log_subscriber.rb` to use the denylist for filtering queries.
* Added `query_name_denylist` attribute to the `Lograge::Sql` configuration and set default values for it.
* Initialized the `query_name_denylist` in the test setup to ensure it has default values.
* Added tests to verify the denylist functionality, ensuring that queries with names matching the denylist are not stored.

### Default value

I addition to SCHEMA-queries, queries with names starting with SolidCable:: are now also skipped. This is to prevent a issue #59 that causes a memory leak.

### Additional Information

I testing this implementation of this gem locally in my application and it successfully skips all queries of solid cable.