### PR TITLE
Compile Regexp on initialization

### DIFF
--- a/lib/lograge/active_record_log_subscriber.rb
+++ b/lib/lograge/active_record_log_subscriber.rb
@@ -33,7 +33,7 @@ module Lograge
     end
 
     def valid?(event)
-      return false if event.payload[:name]&.match?(Regexp.union(Lograge::Sql.query_name_denylist))
+      return false if event.payload[:name]&.match?(Lograge::Sql.query_name_denylist)
 
       # Only store SQL events if `event.duration` is greater than the configured +min_duration+
       # No need to check if +min_duration+ is present before as it defaults to 0

--- a/lib/lograge/sql.rb
+++ b/lib/lograge/sql.rb
@@ -19,7 +19,7 @@ module Lograge
       attr_accessor :query_name_denylist
 
       # Initialise configuration with fallback to default values
-      def setup(config)
+      def setup(config) # rubocop:disable Metrics/AbcSize
         Lograge::Sql.formatter       = config.formatter       || default_formatter
         Lograge::Sql.extract_event   = config.extract_event   || default_extract_event
         Lograge::Sql.min_duration_ms = config.min_duration_ms || 0

--- a/lib/lograge/sql.rb
+++ b/lib/lograge/sql.rb
@@ -24,7 +24,7 @@ module Lograge
         Lograge::Sql.extract_event   = config.extract_event   || default_extract_event
         Lograge::Sql.min_duration_ms = config.min_duration_ms || 0
         Lograge::Sql.query_filter    = config.query_filter
-        Lograge::Sql.query_name_denylist = config.query_name_denylist || [/\ASCHEMA\z/, /\ASolidCable::/]
+        Lograge::Sql.query_name_denylist = Regexp.union(config.query_name_denylist || [/\ASCHEMA\z/, /\ASolidCable::/])
 
         # Disable existing ActiveRecord logging
         unsubscribe_log_subscribers unless config.keep_default_active_record_log

--- a/spec/lograge/active_record_log_subscriber_spec.rb
+++ b/spec/lograge/active_record_log_subscriber_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Lograge::ActiveRecordLogSubscriber do
       stub_const('ActiveRecord::RuntimeRegistry', ar_runtime_registry)
       Lograge::Sql.extract_event = proc {}
       Lograge::Sql.store.clear
-      Lograge::Sql.query_name_denylist = [/\ASCHEMA\z/, /\ASolidCable::/]
+      Lograge::Sql.query_name_denylist = Regexp.union([/\ASCHEMA\z/, /\ASolidCable::/])
     end
 
     context 'with keep_default_active_record_log not set' do


### PR DESCRIPTION
As [suggested](https://github.com/iMacTia/lograge-sql/pull/60#discussion_r1845739763) by @kakubin, this PR moves the compilation of the Regexp from runtime (at every event) to the initialization. This improves performance and resilience, because the regex is only compiled once and compile errors throw at initialization.